### PR TITLE
Prefer node IP addresses for the Harvester config URL

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -179,12 +179,14 @@ func FetchConfigEndpoint(apiClient client.Client) (url string, err error) {
 	}
 
 	// we run as a node Port service just use the first node //
+	preferredAddressTypes := []v1.NodeAddressType{v1.NodeExternalIP, v1.NodeInternalIP, v1.NodeHostName}
 	addressList := nodeList.Items[0].Status.Addresses
-	for _, address := range addressList {
-		if address.Type == "Hostname" {
-			url = "http://" + address.Address + ":30880"
+	for _, addressType := range preferredAddressTypes {
+		for _, address := range addressList {
+			if address.Type == addressType {
+				return "http://" + address.Address + ":30880", nil
+			}
 		}
 	}
-
-	return url, err
+	return "", fmt.Errorf("Could not match endpoint address type")
 }


### PR DESCRIPTION
We cannot expect that a hostname set in the node's `status.addresses` list  is resolvable from machines outside the Operator cluster (In fact Kubernetes only requires kubelet hostnames to be resolvable from the API server).

The PR makes it so that node IP addresses are preferred when constructing the config endpoint URL.

----- 
**Fixes the following issue** 

Harvester installation failed because the config URL hostname could not be resolved on the server.

Node status.Addresses:
```
Addresses:
  InternalIP:  192.168.12.22
  Hostname:    osboxes
```

Installation screen:

![installer-error](https://user-images.githubusercontent.com/3813921/127239161-9cc9f381-2fd4-4324-a7cf-8c5929498eb1.jpg)
